### PR TITLE
Fix `unknown type modemloader_prop` during build

### DIFF
--- a/sepolicy/modemloader.te
+++ b/sepolicy/modemloader.te
@@ -1,8 +1,9 @@
 # modemloader
 type modemloader, domain;
 type modemloader_exec, exec_type, file_type;
+type modemloader_prop, property_type;
 
-init_daemon_domain(modemloader)
+init_daemon_domain(modemloader);
 
 allow modemloader proc:file r_file_perms;
 


### PR DESCRIPTION
This will fix build error for a3y17lte and probably other devices too.

The change is taken from https://review.lineageos.org/c/LineageOS/android_device_samsung_chagalllte/+/223249/2/sepolicy/modemloader.te